### PR TITLE
fix: Improve formatting for nested OIDC discovery errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ hyper-proxy = { version = "0.9.1", default-features = false, features = [
 ] }
 url = { version = "2.5.2", features = ["serde"] }
 headers = "0.3"
+anyhow = "1.0.86"
 
 [lints.rust]
 dead_code = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ publish = ["famedly"]
 [dependencies]
 time = { version = "0.3.36", features = ["serde"] }
 tonic = { version = "0.11.0", features = ["channel"] }
-zitadel = { version = "4.3.5", features = [
+zitadel = { version = "=4.3.5", features = [
   "credentials",
   "api",
   "interceptors",

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,3 +42,25 @@ impl From<ServiceAccountError> for Error {
 
 /// [`Result`] Alias with error set to [`Error`]
 pub type Result<R> = std::result::Result<R, Error>;
+
+#[cfg(test)]
+mod tests {
+	use zitadel::credentials::ServiceAccountError;
+
+	use super::Error;
+
+	#[test]
+	fn test_recursive_error() {
+		let error = ServiceAccountError::DiscoveryError {
+			source: Box::new(ServiceAccountError::DiscoveryError {
+				source: Box::new(ServiceAccountError::DiscoveryError {
+					source: Box::new(Error::TooManyResults("2".to_owned())),
+				}),
+			}),
+		};
+
+		let message = format!("{}", Error::from(error));
+
+		assert_eq!(message, "Zitadel service account error: could not discover OIDC document: could not discover OIDC document: could not discover OIDC document: Too many results! Got: '2'");
+	}
+}


### PR DESCRIPTION
Workaround for #12 