### PR TITLE
Add Organization ID to the header for V2 management queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ pbjson-types = "0.6.0"
 josekit = { git = "https://github.com/famedly/josekit-rs.git", rev = "5941d0f39d034e9c6d96dc47f391926f5e3038fa" }
 cache_control = "0.2.0"
 delegate = "0.13.2"
+famedly_rust_utils = "0.2.0"
 
 [lints.rust]
 dead_code = "warn"

--- a/src/v2/management/mod.rs
+++ b/src/v2/management/mod.rs
@@ -3,23 +3,35 @@ mod models;
 
 use anyhow::{Context, Result};
 use delegate::delegate;
+use famedly_rust_utils::GenericCombinators;
 use futures::Stream;
 pub use models::*;
+use reqwest::header::HeaderValue;
+use serde::{Deserialize, Serialize};
 
 use super::{
 	pagination::{PaginationHandler, PaginationRequest},
 	Zitadel,
 };
 
+/// Metadata/Header for Zitadel organization ID, used to set/get metadata for
+/// organizations.
+pub const HEADER_ZITADEL_ORGANIZATION_ID: &str = "x-zitadel-orgid";
+
 impl Zitadel {
 	/// Create actions. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-create-action)
 	pub async fn create_action(
 		&self,
+		organization_id: Option<String>,
 		body: V1CreateActionRequest,
 	) -> Result<V1CreateActionResponse> {
 		let request = self
 			.client
 			.post(self.make_url("management/v1/actions")?)
+			.header(
+				HEADER_ZITADEL_ORGANIZATION_ID,
+				HeaderValue::from_str(&organization_id.unwrap_or_default())?,
+			)
 			.json(&body)
 			.build()
 			.context("Error building create_action request")?;
@@ -30,12 +42,17 @@ impl Zitadel {
 	/// Update action. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-update-action)
 	pub async fn update_action(
 		&self,
+		organization_id: Option<String>,
 		action_id: String,
 		body: ManagementServiceUpdateActionBody,
 	) -> Result<V1UpdateActionResponse> {
 		let request = self
 			.client
 			.put(self.make_url(&format!("management/v1/actions/{action_id}"))?)
+			.header(
+				HEADER_ZITADEL_ORGANIZATION_ID,
+				HeaderValue::from_str(&organization_id.unwrap_or_default())?,
+			)
 			.json(&body)
 			.build()
 			.context("Error building update_action request")?;
@@ -44,10 +61,18 @@ impl Zitadel {
 	}
 
 	/// Delete action. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-delete-action)
-	pub async fn delete_action(&self, action_id: String) -> Result<V1DeleteActionResponse> {
+	pub async fn delete_action(
+		&self,
+		organization_id: Option<String>,
+		action_id: String,
+	) -> Result<V1DeleteActionResponse> {
 		let request = self
 			.client
 			.delete(self.make_url(&format!("management/v1/actions/{action_id}"))?)
+			.header(
+				HEADER_ZITADEL_ORGANIZATION_ID,
+				HeaderValue::from_str(&organization_id.unwrap_or_default())?,
+			)
 			.json(&ManagementServiceDeleteActionBody::new())
 			.build()
 			.context("Error building delete_action request")?;
@@ -60,6 +85,7 @@ impl Zitadel {
 		&self,
 		body: ListActionsRequest,
 	) -> Result<impl Stream<Item = V1Action> + Send + Sync> {
+		// TODO: Make it possible to use HEADER_ZITADEL_ORGANIZATION_ID
 		Ok(PaginationHandler::<_, V1Action>::new(
 			self.clone(),
 			body,
@@ -67,11 +93,36 @@ impl Zitadel {
 		))
 	}
 
+	/// Search for actions. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-list-actions)
+	pub async fn list_actions_without_pagination(
+		&self,
+		org_id: Option<String>,
+		body: ListActionsRequest,
+	) -> Result<SearchWithoutPaginationResponse<V1Action>> {
+		let request = self
+			.client
+			.post(self.make_url("management/v1/actions/_search")?)
+			.chain_opt(org_id, |req, org_id| req.header(HEADER_ZITADEL_ORGANIZATION_ID, org_id))
+			.json(&body.inner_request)
+			.build()
+			.context("Error building list_actions_without_pagination request")?;
+
+		self.send_request(request).await
+	}
+
 	/// Get a flow. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-get-flow)
-	pub async fn get_flow(&self, flow_type: u32) -> Result<V1GetFlowResponse> {
+	pub async fn get_flow(
+		&self,
+		organization_id: Option<String>,
+		flow_type: u32,
+	) -> Result<V1GetFlowResponse> {
 		let request = self
 			.client
 			.get(self.make_url(&format!("management/v1/flows/{flow_type}"))?)
+			.header(
+				HEADER_ZITADEL_ORGANIZATION_ID,
+				HeaderValue::from_str(&organization_id.unwrap_or_default())?,
+			)
 			.build()
 			.context("Error building get_flow request")?;
 
@@ -81,6 +132,7 @@ impl Zitadel {
 	/// Set trigger actions. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-set-trigger-actions)
 	pub async fn set_trigger_actions(
 		&self,
+		organization_id: Option<String>,
 		// TODO: Should we provide enums for these?
 		flow_type: u32,
 		trigger_type: u32,
@@ -90,6 +142,10 @@ impl Zitadel {
 			.client
 			.post(
 				self.make_url(&format!("management/v1/flows/{flow_type}/trigger/{trigger_type}"))?,
+			)
+			.header(
+				HEADER_ZITADEL_ORGANIZATION_ID,
+				HeaderValue::from_str(&organization_id.unwrap_or_default())?,
 			)
 			.json(&body)
 			.build()
@@ -101,12 +157,17 @@ impl Zitadel {
 	/// Create application. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-add-api-app)
 	pub async fn create_application(
 		&self,
+		organization_id: Option<String>,
 		project_id: String,
 		body: ManagementServiceAddApiAppBody,
 	) -> Result<V1AddApiAppResponse> {
 		let request = self
 			.client
 			.post(self.make_url(&format!("management/v1/projects/{project_id}/apps/api"))?)
+			.header(
+				HEADER_ZITADEL_ORGANIZATION_ID,
+				HeaderValue::from_str(&organization_id.unwrap_or_default())?,
+			)
 			.json(&body)
 			.build()
 			.context("Error building create_application request")?;
@@ -117,6 +178,7 @@ impl Zitadel {
 	/// Remove application. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-remove-app)
 	pub async fn remove_application(
 		&self,
+		organization_id: Option<String>,
 		project_id: String,
 		application_id: String,
 	) -> Result<V1RemoveAppResponse> {
@@ -125,6 +187,10 @@ impl Zitadel {
 				.delete(self.make_url(&format!(
 					"management/v1/projects/{project_id}/apps/{application_id}"
 				))?)
+				.header(
+					HEADER_ZITADEL_ORGANIZATION_ID,
+					HeaderValue::from_str(&organization_id.unwrap_or_default())?,
+				)
 				.build()
 				.context("Error building remove_application request")?;
 
@@ -137,6 +203,7 @@ impl Zitadel {
 		project_id: String,
 		body: ListApplicationsRequest,
 	) -> Result<impl Stream<Item = V1App>> {
+		// TODO: Make it possible to use HEADER_ZITADEL_ORGANIZATION_ID
 		Ok(PaginationHandler::<_, V1App>::new(
 			self.clone(),
 			body,
@@ -144,11 +211,37 @@ impl Zitadel {
 		))
 	}
 
+	/// Search for applications [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-list-apps)
+	pub async fn list_applications_without_pagination(
+		&self,
+		org_id: Option<String>,
+		project_id: String,
+		body: ListApplicationsRequest,
+	) -> Result<SearchWithoutPaginationResponse<V1App>> {
+		let request = self
+			.client
+			.post(self.make_url(&format!("management/v1/projects/{project_id}/apps/_search"))?)
+			.chain_opt(org_id, |req, org_id| req.header(HEADER_ZITADEL_ORGANIZATION_ID, org_id))
+			.json(&body.inner_request)
+			.build()
+			.context("Error building list_applications_without_pagination request")?;
+
+		self.send_request(request).await
+	}
+
 	/// Create project. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-add-project)
-	pub async fn create_project(&self, body: V1AddProjectRequest) -> Result<V1AddProjectResponse> {
+	pub async fn create_project(
+		&self,
+		organization_id: Option<String>,
+		body: V1AddProjectRequest,
+	) -> Result<V1AddProjectResponse> {
 		let request = self
 			.client
 			.post(self.make_url("management/v1/projects")?)
+			.header(
+				HEADER_ZITADEL_ORGANIZATION_ID,
+				HeaderValue::from_str(&organization_id.unwrap_or_default())?,
+			)
 			.json(&body)
 			.build()
 			.context("Error building create_project request")?;
@@ -157,10 +250,18 @@ impl Zitadel {
 	}
 
 	/// Remove project. [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-remove-project)
-	pub async fn remove_project(&self, project_id: String) -> Result<V1RemoveProjectResponse> {
+	pub async fn remove_project(
+		&self,
+		organization_id: Option<String>,
+		project_id: String,
+	) -> Result<V1RemoveProjectResponse> {
 		let request = self
 			.client
 			.delete(self.make_url(&format!("management/v1/projects/{project_id}"))?)
+			.header(
+				HEADER_ZITADEL_ORGANIZATION_ID,
+				HeaderValue::from_str(&organization_id.unwrap_or_default())?,
+			)
 			.build()
 			.context("Error building delete_project request")?;
 
@@ -172,16 +273,34 @@ impl Zitadel {
 		&self,
 		body: ListProjectsRequest,
 	) -> Result<impl Stream<Item = V1Project>> {
+		// TODO: Make it possible to use HEADER_ZITADEL_ORGANIZATION_ID
 		Ok(PaginationHandler::<_, V1Project>::new(
 			self.clone(),
 			body,
 			self.make_url("management/v1/projects/_search")?,
 		))
 	}
+
+	/// Search for projects [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-list-projects)
+	pub async fn list_projects_without_pagination(
+		&self,
+		org_id: Option<String>,
+		body: ListProjectsRequest,
+	) -> Result<SearchWithoutPaginationResponse<V1Project>> {
+		let request = self
+			.client
+			.post(self.make_url("management/v1/projects/_search")?)
+			.chain_opt(org_id, |req, org_id| req.header(HEADER_ZITADEL_ORGANIZATION_ID, org_id))
+			.json(&body.inner_request)
+			.build()
+			.context("Error building list_projects_without_pagination request")?;
+
+		self.send_request(request).await
+	}
 }
 
 /// Pagination-supporting project search
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ListProjectsRequest {
 	inner_request: V1ListProjectsRequest,
 }
@@ -225,6 +344,15 @@ impl ListProjectsRequest {
 	}
 }
 
+/// Response for search without pagination
+#[derive(Clone, Debug, Deserialize)]
+pub struct SearchWithoutPaginationResponse<T> {
+	/// The result of the search
+	pub result: Option<Vec<T>>,
+	/// The details of the search
+	pub details: Option<V1ListDetails>,
+}
+
 impl PaginationRequest for ListProjectsRequest {
 	type Item = V1ListProjectsRequest;
 
@@ -246,7 +374,7 @@ impl PaginationRequest for ListProjectsRequest {
 }
 
 /// Pagination-supporting application search
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ListApplicationsRequest {
 	inner_request: ManagementServiceListAppsBody,
 }
@@ -311,7 +439,7 @@ impl PaginationRequest for ListApplicationsRequest {
 }
 
 /// Pagination-supporting action search
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ListActionsRequest {
 	inner_request: V1ListActionsRequest,
 }

--- a/src/v2/management/models/v1_api_auth_method_type.rs
+++ b/src/v2/management/models/v1_api_auth_method_type.rs
@@ -11,24 +11,17 @@
  */
 
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use serde_json::Value;
-
-use crate::v2::management::models;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct V1ApiAuthMethodType {}
+pub enum V1ApiAuthMethodType {
+	#[serde(rename = "API_AUTH_METHOD_TYPE_BASIC")]
+	Basic,
+	#[serde(rename = "API_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT")]
+	PrivateKeyJwt,
+}
 
 impl V1ApiAuthMethodType {
 	pub fn new() -> V1ApiAuthMethodType {
-		V1ApiAuthMethodType {}
+		V1ApiAuthMethodType::Basic
 	}
 }
-
-// TODO enum
-// List of v1APIAuthMethodType
-//const (
-//
-//
-//
-//)

--- a/src/v2/management/models/v1_oidc_app_type.rs
+++ b/src/v2/management/models/v1_oidc_app_type.rs
@@ -11,24 +11,20 @@
  */
 
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use serde_json::Value;
 
-use crate::v2::management::models;
-
+/// OIDC application type
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct V1OidcAppType {}
+pub enum V1OidcAppType {
+	#[serde(rename = "OIDC_APP_TYPE_WEB")]
+	Web,
+	#[serde(rename = "OIDC_APP_TYPE_USER_AGENT")]
+	UserAgent,
+	#[serde(rename = "OIDC_APP_TYPE_NATIVE")]
+	Native,
+}
 
 impl V1OidcAppType {
 	pub fn new() -> V1OidcAppType {
-		V1OidcAppType {}
+		V1OidcAppType::Web
 	}
 }
-
-// TODO enum
-// List of v1OIDCAppType
-//const (
-//
-//
-//
-//)

--- a/src/v2/management/models/v1_oidc_auth_method_type.rs
+++ b/src/v2/management/models/v1_oidc_auth_method_type.rs
@@ -11,24 +11,22 @@
  */
 
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use serde_json::Value;
 
-use crate::v2::management::models;
-
+/// OIDC authentication method type
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct V1OidcAuthMethodType {}
+pub enum V1OidcAuthMethodType {
+	#[serde(rename = "OIDC_AUTH_METHOD_TYPE_BASIC")]
+	Basic,
+	#[serde(rename = "OIDC_AUTH_METHOD_TYPE_POST")]
+	Post,
+	#[serde(rename = "OIDC_AUTH_METHOD_TYPE_NONE")]
+	None,
+	#[serde(rename = "OIDC_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT")]
+	PrivateKeyJwt,
+}
 
 impl V1OidcAuthMethodType {
 	pub fn new() -> V1OidcAuthMethodType {
-		V1OidcAuthMethodType {}
+		V1OidcAuthMethodType::Basic
 	}
 }
-
-// TODO enum
-// List of v1OIDCAuthMethodType
-//const (
-//
-//
-//
-//)

--- a/src/v2/management/models/v1_oidc_grant_type.rs
+++ b/src/v2/management/models/v1_oidc_grant_type.rs
@@ -11,24 +11,24 @@
  */
 
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use serde_json::Value;
 
-use crate::v2::management::models;
-
+/// OIDC grant type
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct V1OidcGrantType {}
+pub enum V1OidcGrantType {
+	#[serde(rename = "OIDC_GRANT_TYPE_AUTHORIZATION_CODE")]
+	AuthorizationCode,
+	#[serde(rename = "OIDC_GRANT_TYPE_IMPLICIT")]
+	Implicit,
+	#[serde(rename = "OIDC_GRANT_TYPE_REFRESH_TOKEN")]
+	RefreshToken,
+	#[serde(rename = "OIDC_GRANT_TYPE_DEVICE_CODE")]
+	DeviceCode,
+	#[serde(rename = "OIDC_GRANT_TYPE_TOKEN_EXCHANGE")]
+	TokenExchange,
+}
 
 impl V1OidcGrantType {
 	pub fn new() -> V1OidcGrantType {
-		V1OidcGrantType {}
+		V1OidcGrantType::AuthorizationCode
 	}
 }
-
-// TODO enum
-// List of v1OIDCGrantType
-//const (
-//
-//
-//
-//)

--- a/src/v2/management/models/v1_oidc_response_type.rs
+++ b/src/v2/management/models/v1_oidc_response_type.rs
@@ -11,24 +11,20 @@
  */
 
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use serde_json::Value;
 
-use crate::v2::management::models;
-
+/// OIDC response type
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct V1OidcResponseType {}
+pub enum V1OidcResponseType {
+	#[serde(rename = "OIDC_RESPONSE_TYPE_CODE")]
+	Code,
+	#[serde(rename = "OIDC_RESPONSE_TYPE_ID_TOKEN")]
+	IdToken,
+	#[serde(rename = "OIDC_RESPONSE_TYPE_ID_TOKEN_TOKEN")]
+	IdTokenToken,
+}
 
 impl V1OidcResponseType {
 	pub fn new() -> V1OidcResponseType {
-		V1OidcResponseType {}
+		V1OidcResponseType::Code
 	}
 }
-
-// TODO enum
-// List of v1OIDCResponseType
-//const (
-//
-//
-//
-//)

--- a/src/v2/management/models/v1_oidc_token_type.rs
+++ b/src/v2/management/models/v1_oidc_token_type.rs
@@ -11,24 +11,18 @@
  */
 
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use serde_json::Value;
 
-use crate::v2::management::models;
-
+/// OIDC access token type
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct V1OidcTokenType {}
+pub enum V1OidcTokenType {
+	#[serde(rename = "OIDC_TOKEN_TYPE_BEARER")]
+	Bearer,
+	#[serde(rename = "OIDC_TOKEN_TYPE_JWT")]
+	Jwt,
+}
 
 impl V1OidcTokenType {
 	pub fn new() -> V1OidcTokenType {
-		V1OidcTokenType {}
+		V1OidcTokenType::Bearer
 	}
 }
-
-// TODO enum
-// List of v1OIDCTokenType
-//const (
-//
-//
-//
-//)

--- a/src/v2/management/models/v1_oidc_version.rs
+++ b/src/v2/management/models/v1_oidc_version.rs
@@ -11,24 +11,16 @@
  */
 
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use serde_json::Value;
 
-use crate::v2::management::models;
-
+/// OIDC version
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct V1OidcVersion {}
+pub enum V1OidcVersion {
+	#[serde(rename = "OIDC_VERSION_1_0")]
+	V1_0,
+}
 
 impl V1OidcVersion {
 	pub fn new() -> V1OidcVersion {
-		V1OidcVersion {}
+		V1OidcVersion::V1_0
 	}
 }
-
-// TODO enum
-// List of v1OIDCVersion
-//const (
-//
-//
-//
-//)

--- a/src/v2/management/models/v1_project_state.rs
+++ b/src/v2/management/models/v1_project_state.rs
@@ -11,24 +11,20 @@
  */
 
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use serde_json::Value;
 
-use crate::v2::management::models;
-
+/// Project state
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct V1ProjectState {}
+pub enum V1ProjectState {
+	#[serde(rename = "PROJECT_STATE_UNSPECIFIED")]
+	Unspecified,
+	#[serde(rename = "PROJECT_STATE_ACTIVE")]
+	Active,
+	#[serde(rename = "PROJECT_STATE_INACTIVE")]
+	Inactive,
+}
 
 impl V1ProjectState {
 	pub fn new() -> V1ProjectState {
-		V1ProjectState {}
+		V1ProjectState::Unspecified
 	}
 }
-
-// TODO enum
-// List of v1ProjectState
-//const (
-//
-//
-//
-//)

--- a/src/v2/management/models/v1_text_query_method.rs
+++ b/src/v2/management/models/v1_text_query_method.rs
@@ -11,24 +11,30 @@
  */
 
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use serde_json::Value;
 
-use crate::v2::management::models;
-
+/// Text query method
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct V1TextQueryMethod {}
+pub enum V1TextQueryMethod {
+	#[serde(rename = "TEXT_QUERY_METHOD_EQUALS")]
+	Equals,
+	#[serde(rename = "TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE")]
+	EqualsIgnoreCase,
+	#[serde(rename = "TEXT_QUERY_METHOD_STARTS_WITH")]
+	StartsWith,
+	#[serde(rename = "TEXT_QUERY_METHOD_STARTS_WITH_IGNORE_CASE")]
+	StartsWithIgnoreCase,
+	#[serde(rename = "TEXT_QUERY_METHOD_CONTAINS")]
+	Contains,
+	#[serde(rename = "TEXT_QUERY_METHOD_CONTAINS_IGNORE_CASE")]
+	ContainsIgnoreCase,
+	#[serde(rename = "TEXT_QUERY_METHOD_ENDS_WITH")]
+	EndsWith,
+	#[serde(rename = "TEXT_QUERY_METHOD_ENDS_WITH_IGNORE_CASE")]
+	EndsWithIgnoreCase,
+}
 
 impl V1TextQueryMethod {
 	pub fn new() -> V1TextQueryMethod {
-		V1TextQueryMethod {}
+		V1TextQueryMethod::Equals
 	}
 }
-
-// TODO enum
-// List of v1TextQueryMethod
-//const (
-//
-//
-//
-//)

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -21,6 +21,10 @@ use url::Url;
 /// Default timeout value to be used in various places
 const DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Metadata/Header for Zitadel organization ID, used to set/get metadata for
+/// organizations.
+pub const HEADER_ZITADEL_ORGANIZATION_ID: &str = "x-zitadel-orgid";
+
 /// Zitadel client for using the HTTP v2 api
 #[derive(Debug, Clone)]
 pub struct Zitadel {

--- a/src/v2/users/mod.rs
+++ b/src/v2/users/mod.rs
@@ -142,6 +142,7 @@ impl Zitadel {
 		self.send_request(request).await
 	}
 	/// List links to an identity provider of an user
+	/// [Docs](https://zitadel.com/docs/apis/resources/user_service_v2/user-service-list-idp-links)
 	pub fn list_idp_links(
 		&self,
 		user_id: &str,
@@ -151,6 +152,7 @@ impl Zitadel {
 			self.clone(),
 			body,
 			self.make_url(&format!("/v2/users/{user_id}/links/_search"))?,
+			None, // Endpoint does not support org_id
 		))
 	}
 	/// List passkeys of an user
@@ -172,12 +174,19 @@ impl Zitadel {
 	/// Search Users
 	/// Search for users. By default, we will return users of your organization.
 	/// Make sure to include a limit and sorting for pagination.
+	/// [Docs](https://zitadel.com/docs/apis/resources/user_service_v2/user-service-list-users)
 	pub fn list_users(
 		&self,
 		body: ListUsersRequest,
 	) -> Result<impl Stream<Item = User> + Send + Sync> {
-		Ok(PaginationHandler::<_, User>::new(self.clone(), body, self.make_url("/v2/users")?))
+		Ok(PaginationHandler::<_, User>::new(
+			self.clone(),
+			body,
+			self.make_url("/v2/users")?,
+			None, // Endpoint does not support org_id
+		))
 	}
+
 	/// Lock user
 	/// The state of the user will be changed to 'locked'. The user will not be
 	/// able to log in anymore. The endpoint returns an error if the user is
@@ -667,6 +676,7 @@ impl Zitadel {
 		self.send_request(request).await
 	}
 	/// Get the metadata of a user filtered by your query
+	/// [Docs](https://zitadel.com/docs/apis/resources/mgmt/management-service-list-user-metadata)
 	pub fn list_user_metadata(
 		&self,
 		user_id: &str,
@@ -676,6 +686,7 @@ impl Zitadel {
 			self.clone(),
 			body,
 			self.make_url(&format!("/management/v1/users/{user_id}/metadata/_search"))?,
+			None, // TODO: Breaking change -> possibility to add org_id to function args
 		))
 	}
 }


### PR DESCRIPTION
This is necessary in order to set up actions and triggers for particular organizations.

I have also update a couple of Enums in Models to get rid of Error tracing messages from the newly added e2e tests.