### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/ff-merge.yml
+++ b/.github/workflows/ff-merge.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Fast forwarding
-        uses: sequoia-pgp/fast-forward@v1
+        uses: sequoia-pgp/fast-forward@e2c6fb52f977408912b000ad4577a669f1c4f5fe
         with:
           merge: true
           comment: on-error

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
         gitlab_pass: ${{ secrets.GITLAB_PASS }}
 
     - name: Caching
-      uses: Swatinem/rust-cache@68b3cb7503c78e67dae8373749990a220eb65352
+      uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68
       with:
         cache-on-failure: true
         cache-all-crates: true
@@ -86,7 +86,7 @@ jobs:
       run: rustup component add llvm-tools-preview --toolchain stable-x86_64-unknown-linux-gnu
 
     - name: Caching
-      uses: Swatinem/rust-cache@68b3cb7503c78e67dae8373749990a220eb65352
+      uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68
       with:
         cache-on-failure: true
         cache-all-crates: true
@@ -111,13 +111,13 @@ jobs:
         docker compose --project-directory ./tests/environment logs
 
     - name: Codecov - Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@ca0a928a4cb3911011e868128a5cd90437c12db1
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         files: "lcov.info"
 
     - name: Codecov - Upload test results
-      uses: codecov/test-results-action@v1
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3
       with:
         token: ${{secrets.CODECOV_TOKEN}}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout current repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       with:
         path: head
 
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout current repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       with:
         path: head
 
@@ -123,7 +123,7 @@ jobs:
 
   publish:
     needs: [simple-checks, tests]
-    uses: famedly/backend-build-workflows/.github/workflows/publish-crate.yml@v2
+    uses: famedly/backend-build-workflows/.github/workflows/publish-crate.yml@fcc2ec82a725d5c4c9c6a8f19e8df101c178dcb6
     with:
       registry-name: "crates-io"
       registry-index: "https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
## Summary
- Update GitHub Actions in workflows to the latest upstream default-branch commit SHAs.
- Keep existing action paths and only replace refs after `@`.

## Verification
- Checked generated diff to include only `.github/**/*.yml` / `.github/**/*.yaml` workflow action refs.
- CI on this PR should validate the updated action versions.